### PR TITLE
Adds pretty-quick to lint staged files only

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,3 @@
 {
-  "bracketSpacing": true,
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "printWidth": 80
+  "singleQuote": true
 }

--- a/angular.json
+++ b/angular.json
@@ -19,10 +19,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
               "src/scss/style.scss",
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
@@ -39,9 +36,7 @@
               "src/scss/core.scss"
             ],
             "stylePreprocessorOptions": {
-              "includePaths": [
-                "./node_modules"
-              ]
+              "includePaths": ["./node_modules"]
             },
             "scripts": [
               "node_modules/jquery/dist/jquery.min.js",
@@ -69,10 +64,7 @@
               "node_modules/@cartesian-ui/js-axis/axis.message.swal.min.js",
               "node_modules/@cartesian-ui/js-axis/axis.notification.swal.min.js"
             ],
-            "allowedCommonJsDependencies": [
-              "lodash",
-              "chart.js"
-            ]
+            "allowedCommonJsDependencies": ["lodash", "chart.js"]
           },
           "configurations": {
             "production": {
@@ -129,7 +121,8 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "browserTarget": "cartesian-ui:build",
-            "proxyConfig": "proxy.conf.json"
+            "proxyConfig": "proxy.conf.json",
+            "hmrWarning": false
           },
           "configurations": {
             "production": {
@@ -153,10 +146,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
               "src/scss/style.scss",
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
@@ -173,9 +163,7 @@
               "src/scss/core.scss"
             ],
             "stylePreprocessorOptions": {
-              "includePaths": [
-                "./node_modules"
-              ]
+              "includePaths": ["./node_modules"]
             },
             "scripts": [
               "node_modules/jquery/dist/jquery.min.js",
@@ -209,9 +197,7 @@
               "tsconfig.spec.json",
               "e2e/tsconfig.json"
             ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -227,7 +213,8 @@
           }
         }
       }
-    }},
+    }
+  },
   "defaultProject": "cartesian-ui",
   "schematics": {
     "@schematics/angular:component": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run format:write --satged && ng lint --fix"
+      "pre-commit": "npm run format:write --satged && ng lint"
     }
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
+    "hmr": "ng serve --hmr --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
@@ -13,7 +14,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --no-restage --bail && ng lint --fix"
+      "pre-commit": "pretty-quick --staged && ng lint --fix"
     }
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run format:write --satged && ng lint"
+      "pre-commit": "pretty-quick --staged --satged && ng lint --fix"
     }
   },
   "private": true,
@@ -107,6 +107,7 @@
     "karma-jasmine-html-reporter": "^1.5.4",
     "nswag": "^13.7.4",
     "prettier": "^2.1.2",
+    "pretty-quick": "^3.0.2",
     "protractor": "~7.0.0",
     "ts-node": "~9.0.0",
     "tslint": "~6.1.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --satged && ng lint --fix"
+      "pre-commit": "pretty-quick --staged --no-restage --bail && ng lint --fix"
     }
   },
   "private": true,

--- a/src/app/account/ui/tenant/tenant-change.component.ts
+++ b/src/app/account/ui/tenant/tenant-change.component.ts
@@ -1,4 +1,4 @@
-﻿import { Component, OnInit, Injector } from '@angular/core';
+import { Component, OnInit, Injector } from '@angular/core';
 import { BaseComponent } from '@shared/ui';
 import { TenantChangeDialogComponent } from './tenant-change-dialog.component';
 import { BsModalService } from 'ngx-bootstrap/modal';

--- a/src/app/app-initializer.service.ts
+++ b/src/app/app-initializer.service.ts
@@ -98,6 +98,7 @@ export class AppInitializerService {
       });
   }
 
+  // tslint:disable:no-string-literal
   private getUserConfiguration(callback: () => void): void {
     // ----------------------------------------------------------
     //   TODO: Policy for Axis Object Holding User Configuration
@@ -108,7 +109,7 @@ export class AppInitializerService {
     // so these will not be required to part of state.
 
     const cookieLangValue = axis.utils.getCookieValue(
-      'Axis.Localization.CultureName'
+      `Axis.Localization.CultureName`
     );
     const token = this._tokenService.getToken();
     const tenantId = this._multiTenancyService.getTenantId();
@@ -117,16 +118,16 @@ export class AppInitializerService {
 
     if (cookieLangValue) {
       requestHeaders[
-        '.Axis.Culture'
+        `.Axis.Culture`
       ] = `c=${cookieLangValue}|uic=${cookieLangValue}`;
     }
 
     if (tenantId) {
-      requestHeaders['Axis.TenantId'] = `${tenantId}`;
+      requestHeaders[`Axis.TenantId`] = `${tenantId}`;
     }
 
     if (token) {
-      requestHeaders['Authorization'] = `Bearer ${token}`;
+      requestHeaders[`Authorization`] = `Bearer ${token}`;
     }
 
     this._httpClient

--- a/src/app/app-initializer.service.ts
+++ b/src/app/app-initializer.service.ts
@@ -2,7 +2,12 @@ import { Injectable, Injector } from '@angular/core';
 import { PlatformLocation, registerLocaleData } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../environments/environment';
-import { AppConstants, UiService, MultiTenancyService, TokenService } from '@cartesian-ui/ng-axis';
+import {
+  AppConstants,
+  UiService,
+  MultiTenancyService,
+  TokenService,
+} from '@cartesian-ui/ng-axis';
 import { SessionService } from '@shared/services';
 import { User } from '@app/account/models';
 import * as moment from 'moment';
@@ -102,22 +107,26 @@ export class AppInitializerService {
     // these values will have no impact on state, and these are supposed to be remain constant through application live cycle,
     // so these will not be required to part of state.
 
-    const cookieLangValue = axis.utils.getCookieValue('Axis.Localization.CultureName');
+    const cookieLangValue = axis.utils.getCookieValue(
+      'Axis.Localization.CultureName'
+    );
     const token = this._tokenService.getToken();
     const tenantId = this._multiTenancyService.getTenantId();
 
     const requestHeaders = {};
 
-    if(cookieLangValue) {
-      requestHeaders['.Axis.Culture'] = `c=${cookieLangValue}|uic=${cookieLangValue}`;
+    if (cookieLangValue) {
+      requestHeaders[
+        '.Axis.Culture'
+      ] = `c=${cookieLangValue}|uic=${cookieLangValue}`;
     }
 
-    if(tenantId) {
+    if (tenantId) {
       requestHeaders['Axis.TenantId'] = `${tenantId}`;
     }
 
     if (token) {
-      requestHeaders["Authorization"] = `Bearer ${token}`;
+      requestHeaders['Authorization'] = `Bearer ${token}`;
     }
 
     this._httpClient

--- a/src/app/demo/views/notifications/alerts.component.ts
+++ b/src/app/demo/views/notifications/alerts.component.ts
@@ -64,7 +64,7 @@ export class AlertsComponent {
   messages = [
     'You successfully read this important alert message.',
     'Now this text is different from what it was before. Go ahead and click the button one more time',
-    'Well done! Click reset button and you\'ll see the first message',
+    "Well done! Click reset button and you'll see the first message",
   ];
 
   alertsDismiss: any = [];

--- a/src/app/demo/views/notifications/alerts.component.ts
+++ b/src/app/demo/views/notifications/alerts.component.ts
@@ -37,7 +37,7 @@ export class AlertsComponent {
     },
     {
       type: 'info',
-      msg: `This alert needs your attention, but it is not super important.`,
+      msg: `This alert needs your attention, but it's not super important.`,
     },
     {
       type: 'danger',

--- a/src/app/demo/views/notifications/alerts.component.ts
+++ b/src/app/demo/views/notifications/alerts.component.ts
@@ -37,7 +37,7 @@ export class AlertsComponent {
     },
     {
       type: 'info',
-      msg: `This alert needs your attention, but it's not super important.`,
+      msg: `This alert needs your attention, but it is not super important.`,
     },
     {
       type: 'danger',

--- a/src/app/demo/views/notifications/alerts.component.ts
+++ b/src/app/demo/views/notifications/alerts.component.ts
@@ -62,9 +62,9 @@ export class AlertsComponent {
 
   index = 0;
   messages = [
-    'You successfully read this important alert message.',
-    'Now this text is different from what it was before. Go ahead and click the button one more time',
-    "Well done! Click reset button and you'll see the first message",
+    `You successfully read this important alert message.`,
+    `Now this text is different from what it was before. Go ahead and click the button one more time`,
+    `Well done! Click reset button and you'll see the first message`,
   ];
 
   alertsDismiss: any = [];

--- a/src/app/shared/helpers/url.helper.ts
+++ b/src/app/shared/helpers/url.helper.ts
@@ -9,7 +9,7 @@ export class UrlHelper {
       .replace(/(^\?)/, '')
       .split('&')
       .map(
-        function(n) {
+        function (n) {
           return (n = n.split('=')), (this[n[0]] = n[1]), this;
         }.bind({})
       )[0];

--- a/src/app/shared/services/session.service.ts
+++ b/src/app/shared/services/session.service.ts
@@ -22,6 +22,7 @@ export class SessionService {
     private _multiTenancyService: MultiTenancyService
   ) {}
 
+  // tslint:disable:no-string-literal
   init(): Promise<any> {
     const token = this._tokenService.getToken();
     const tenantId = this._multiTenancyService.getTenantId();

--- a/src/app/shared/services/session.service.ts
+++ b/src/app/shared/services/session.service.ts
@@ -28,12 +28,12 @@ export class SessionService {
 
     const requestHeaders = {};
 
-    if (token) {
-      requestHeaders.Authorization = `Bearer ${token}`;
+    if(tenantId) {
+      requestHeaders['Axis.TenantId'] = `${tenantId}`;
     }
 
-    if (tenantId) {
-      requestHeaders['Axis.TenantId'] = `${tenantId}`;
+    if (token) {
+      requestHeaders["Authorization"] = `Bearer ${token}`;
     }
 
     return new Promise<any>((resolve, reject) => {

--- a/src/app/shared/services/session.service.ts
+++ b/src/app/shared/services/session.service.ts
@@ -28,12 +28,12 @@ export class SessionService {
 
     const requestHeaders = {};
 
-    if(tenantId) {
+    if (tenantId) {
       requestHeaders['Axis.TenantId'] = `${tenantId}`;
     }
 
     if (token) {
-      requestHeaders["Authorization"] = `Bearer ${token}`;
+      requestHeaders['Authorization'] = `Bearer ${token}`;
     }
 
     return new Promise<any>((resolve, reject) => {

--- a/src/hmr.ts
+++ b/src/hmr.ts
@@ -1,15 +1,19 @@
 import { NgModuleRef, ApplicationRef } from '@angular/core';
 import { createNewHosts } from '@angularclass/hmr';
 
-export const hmrBootstrap = (module: any, bootstrap: () => Promise<NgModuleRef<any>>) => {
-    let ngModule: NgModuleRef<any>;
-    module.hot.accept();
-    bootstrap().then(mod => ngModule = mod);
-    module.hot.dispose(() => {
-        const appRef: ApplicationRef = ngModule.injector.get(ApplicationRef);
-        const elements = appRef.components.map(c => c.location.nativeElement);
-        const makeVisible = createNewHosts(elements);
-        ngModule.destroy();
-        makeVisible();
-    });
+export const hmrBootstrap = (
+  module: any,
+  bootstrap: () => Promise<NgModuleRef<any>>
+) => {
+  let ngModule: NgModuleRef<any>;
+  console.log('🔁  HMR Reloading `...');
+  module.hot.accept();
+  bootstrap().then((mod) => (ngModule = mod));
+  module.hot.dispose(() => {
+    const appRef: ApplicationRef = ngModule.injector.get(ApplicationRef);
+    const elements = appRef.components.map((c) => c.location.nativeElement);
+    const makeVisible = createNewHosts(elements);
+    ngModule.destroy();
+    makeVisible();
+  });
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ if (environment.production) {
 }
 
 const bootstrap = () => {
+  console.log('🚀 Bootstrapping ...');
   return platformBrowserDynamic().bootstrapModule(AppModule);
 };
 
@@ -20,13 +21,16 @@ const bootstrap = () => {
  */
 
 if (environment.hmr) {
+  console.log('✅ Client-side HMR Enabled!');
   // tslint:disable:no-string-literal
   if (module['hot']) {
+    console.log('🔥▶ HRM Bootstrap!');
     hmrBootstrap(module, bootstrap); // HMR enabled bootstrap
   } else {
     console.error('HMR is not enabled for webpack-dev-server!');
     console.log('Are you using the --hmr flag for ng serve?');
   }
 } else {
-  bootstrap(); // Regular bootstrap
+  console.log('▶ Regular Bootstrap!');
+  bootstrap();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ const bootstrap = () => {
  */
 
 if (environment.hmr) {
-  if (module.hot) {
+  if (module["hot"]) {
     hmrBootstrap(module, bootstrap); // HMR enabled bootstrap
   } else {
     console.error('HMR is not enabled for webpack-dev-server!');

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ const bootstrap = () => {
  */
 
 if (environment.hmr) {
-  if (module["hot"]) {
+  if (module['hot']) {
     hmrBootstrap(module, bootstrap); // HMR enabled bootstrap
   } else {
     console.error('HMR is not enabled for webpack-dev-server!');

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ const bootstrap = () => {
  */
 
 if (environment.hmr) {
+  // tslint:disable:no-string-literal
   if (module['hot']) {
     hmrBootstrap(module, bootstrap); // HMR enabled bootstrap
   } else {

--- a/tslint.json
+++ b/tslint.json
@@ -2,10 +2,7 @@
   "extends": ["tslint:recommended", "tslint-config-prettier"],
   "rules": {
     "align": {
-      "options": [
-        "parameters",
-        "statements"
-      ]
+      "options": ["parameters", "statements"]
     },
     "array-type": false,
     "arrow-return-shorthand": true,
@@ -16,34 +13,16 @@
     "component-class-suffix": true,
     "contextual-lifecycle": true,
     "directive-class-suffix": true,
-    "directive-selector": [
-      true,
-      "attribute",
-      "",
-      "camelCase"
-    ],
-    "component-selector": [
-      true,
-      "element",
-      "",
-      "kebab-case"
-    ],
+    "directive-selector": [true, "attribute", "", "camelCase"],
+    "component-selector": [true, "element", "", "kebab-case"],
     "eofline": true,
-    "import-blacklist": [
-      true,
-      "rxjs/Rx"
-    ],
+    "import-blacklist": [true, "rxjs/Rx"],
     "import-spacing": true,
     "indent": {
-      "options": [
-        "spaces"
-      ]
+      "options": ["spaces"]
     },
     "max-classes-per-file": false,
-    "max-line-length": [
-      true,
-      140
-    ],
+    "max-line-length": [true, 140],
     "member-ordering": [
       true,
       {
@@ -55,35 +34,17 @@
         ]
       }
     ],
-    "no-console": [
-      true,
-      "debug",
-      "info",
-      "time",
-      "timeEnd",
-      "trace"
-    ],
+    "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
     "no-empty": false,
-    "no-inferrable-types": [
-      true,
-      "ignore-params"
-    ],
+    "no-inferrable-types": [true, "ignore-params"],
     "no-non-null-assertion": true,
     "no-redundant-jsdoc": true,
     "no-switch-case-fall-through": true,
     "no-var-requires": false,
-    "object-literal-key-quotes": [
-      true,
-      "as-needed"
-    ],
-    "quotemark": [
-      true,
-      "single"
-    ],
+    "object-literal-key-quotes": [true, "as-needed"],
+    "quotemark": [true, "single"],
     "semicolon": {
-      "options": [
-        "always"
-      ]
+      "options": ["always"]
     },
     "space-before-function-paren": {
       "options": {
@@ -142,9 +103,8 @@
     "template-banana-in-box": true,
     "template-no-negated-async": true,
     "use-lifecycle-interface": true,
-    "use-pipe-transform-interface": true
+    "use-pipe-transform-interface": true,
+    "no-string-literal": false
   },
-  "rulesDirectory": [
-    "codelyzer"
-  ]
+  "rulesDirectory": ["codelyzer"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -103,8 +103,7 @@
     "template-banana-in-box": true,
     "template-no-negated-async": true,
     "use-lifecycle-interface": true,
-    "use-pipe-transform-interface": true,
-    "no-string-literal": false
+    "use-pipe-transform-interface": true
   },
   "rulesDirectory": ["codelyzer"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -48,7 +48,7 @@
     },
     "space-before-function-paren": {
       "options": {
-        "anonymous": "never",
+        "anonymous": "always",
         "asyncArrow": "always",
         "constructor": "never",
         "method": "never",


### PR DESCRIPTION
- Adds pretty-quick to lint staged files only
- Updates pre-commit hook to use pretty-quick instead if using own prettier commands
- quotemark configurations is having conflicts between prettier and tslint, possible solution is avoid using single quotes where ever it is possible and user string literal instead.
- space-before-function-paren also conflicts with prettier as there is not such configuration in prettier, this can create problem.
- Pull request contains too many commits, some are just produced during test lint configurations.